### PR TITLE
Produce the means to replace while also respecting HTML tags

### DIFF
--- a/assets/twigs/abbreviator-settings.twig
+++ b/assets/twigs/abbreviator-settings.twig
@@ -1,5 +1,10 @@
 <section class="wrap" aria-labelledby="entry-title">
-  <h1 id="entry-title">Abbreviator Settings</h1>
+  <h1 id="entry-title">Abbreviations</h1>
+  <p>Enter abbreviations into the first column and their meanings into the
+    second; for example, you would enter ASAP into the first field and "As
+    Soon As Possible" into the one next to it. Click the add button to create
+    more fields. When you've entered the ones you need to record, click the
+    save button. You can always return here later to add more.</p>
 
   <form method="post" action="{{ function('admin_url', 'admin-post.php') }}">
     <div id="abbreviator-form">

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "ext-dom": "*",
     "ext-json": "*",
     "dashifen/wp-handler": "^10.2",
-    "timber/timber": "^1.18",
+    "timber/timber": "^1.18"
   },
   "config": {
     "optimize-autoloader": true,

--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,10 @@
   },
   "require": {
     "php": ">=7.4",
+    "ext-dom": "*",
+    "ext-json": "*",
     "dashifen/wp-handler": "^10.2",
     "timber/timber": "^1.18",
-    "ext-json": "*"
   },
   "config": {
     "optimize-autoloader": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e24d9539ee201c575e920377dcf591ae",
+    "content-hash": "63889a3252bebe69874cd5f4e8860316",
     "packages": [
         {
             "name": "altorouter/altorouter",
@@ -939,6 +939,7 @@
     "prefer-lowest": false,
     "platform": {
         "php": ">=7.4",
+        "ext-dom": "*",
         "ext-json": "*"
     },
     "platform-dev": [],

--- a/src/Agents/ContentFilteringAgent.php
+++ b/src/Agents/ContentFilteringAgent.php
@@ -301,12 +301,12 @@ class ContentFilteringAgent extends AbstractPluginAgent
     // if we're here, then the only abbreviations in our $content are outside
     // of tags.  that means we can do our replacements using str_replace and
     // the arrays we can extract from our abbreviation collection.
+  
+    $tags = $this->abbreviations->getTags();
+    $abbreviations = $this->abbreviations->getAbbreviations();
+    $content = str_replace($abbreviations, $tags, $content);
+    return $content;
     
-    return str_replace(
-      $content,
-      $this->abbreviations->getAbbreviations(),
-      $this->abbreviations->getTags()
-    );
   }
   
   /**

--- a/src/Agents/ContentFilteringAgent.php
+++ b/src/Agents/ContentFilteringAgent.php
@@ -306,7 +306,6 @@ class ContentFilteringAgent extends AbstractPluginAgent
     $abbreviations = $this->abbreviations->getAbbreviations();
     $content = str_replace($abbreviations, $tags, $content);
     return $content;
-    
   }
   
   /**

--- a/src/Agents/SettingsAgent.php
+++ b/src/Agents/SettingsAgent.php
@@ -54,7 +54,7 @@ class SettingsAgent extends AbstractPluginAgent
   protected function addAbbreviatorSettings(): void
   {
     $submenuItemSettings = [
-      'pageTitle'  => 'Abbreviator',
+      'pageTitle'  => 'Abbreviations',
       'capability' => $this->getCapabilityForAction('access'),
       'method'     => 'showAbbreviatorSettings',
     ];


### PR DESCRIPTION
In case someone puts an abbreviation within an HTML tag—in an image's alt attribute, for example—this PR adds code that should make our replacements around HTML tags or identify that we can't do so and flag the post in its meta.  